### PR TITLE
Add Share capability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ConfettiExplosion from "react-confetti-explosion";
 import Header from "./components/Header";
 
 import { useLoaderData } from "react-router-dom";
+import Share from "./components/Share";
 
 type GameState = "guessing" | "won" | "lost";
 
@@ -122,6 +123,7 @@ function App() {
           role="alert"
         >
           {params.text}
+          {gameState === "won" && <Share guesses={guesses} dailyPuzzle={currentPuzzle(puzzleCategoryData)}/>}
         </div>
       </div>
     );

--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { ComposerWork } from "../composerWork";
+import { DailyPuzzle} from "../dailyPuzzle";
+
+type Props = {
+    guesses: ComposerWork[];
+    dailyPuzzle: DailyPuzzle;
+};
+
+function Share(props: Props) {    
+    const { guesses, dailyPuzzle } = props;
+    const [isTextCopied, setIsTextCopied] = useState(false);
+
+    // Copy the puzzle date and the user's guesses to the clipboard to share on social media
+    const copyShareToClipboard = (): void => {
+        const puzzleAnswer = dailyPuzzle.puzzleAnswer;
+        let stringifiedGuesses = `Music Wordle ${dailyPuzzle.puzzleDate.toLocaleDateString()}\n`;
+        guesses.forEach((guess: ComposerWork) => {
+            stringifiedGuesses += (guess.composer === puzzleAnswer.composer ? "🟩" : "🟥");
+            stringifiedGuesses += (guess.work === puzzleAnswer.work ? "🟩\n" : "🟥\n");
+        });
+        navigator.clipboard.writeText(stringifiedGuesses);
+        setIsTextCopied(true);
+    }
+
+    return (
+        <div className="mt-1">
+            <button
+                className="px-2 py-1 font-semibold text-sm bg-cyan-500 border-solid border-2 border-sky-700 text-neutral-50 rounded-lg md:rounded-lg shadow-sm w-full md:w-auto md:py-2 hover:bg-sky-600 align-middle"
+                onClick={copyShareToClipboard}
+            >
+                <span>Share</span>
+            </button>
+            { isTextCopied && <div className="mt-1">Copied results to clipboard ✅</div> }
+        </div>
+    );
+}
+
+export default Share;


### PR DESCRIPTION
Adds the "Share" capability which will show if a player wins the game.

Feel free to change the clipboard output/messaging if you want

<img width="615" alt="image" src="https://github.com/Heanthor/music-wordle/assets/11641649/4ad714e8-5034-4ad1-aef6-8f93b6bf2032">

<img width="611" alt="image" src="https://github.com/Heanthor/music-wordle/assets/11641649/e6159a7d-c775-4f2f-9970-39c372ebec7f">

output:
```
Music Wordle 10/17/2023
🟥🟥
🟩🟥
🟩🟩
```
